### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-#Aaron's Instructions
+# Aaron's Instructions
 
-###To run this, you simply launch a static server and open the `index.html`
+### To run this, you simply launch a static server and open the `index.html`


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
